### PR TITLE
n7x_default.xml: Sync android_system_qcom

### DIFF
--- a/n7x_default.xml
+++ b/n7x_default.xml
@@ -60,6 +60,7 @@
   <project path="system/extras" name="android_system_extras" remote="du" revision="n7x-caf" />
   <project path="system/media" name="android_system_media" remote="du" revision="n7x-caf" />
   <project path="system/netd" name="android_system_netd" remote="du" revision="n7x-caf" />
+  <project path="system/qcom" name="android_system_qcom" remote="du" revision="n7x-caf" />
   <project path="system/sepolicy" name="android_system_sepolicy" remote="du" />
   <project path="system/vold" name="android_system_vold" remote="du" revision="n7x-caf" />
 


### PR DESCRIPTION
*This repo is needed for the wlan sdk to work. Surprisingly it is not there in the manifest already.